### PR TITLE
Bug fixed, node variables cleanup  properly

### DIFF
--- a/menuflow/flow.py
+++ b/menuflow/flow.py
@@ -130,7 +130,5 @@ class Flow:
             return
 
         node_initialized.room = room
-        node_initialized.variables = self.flow_variables or {}
-        node_initialized.variables.update(room._variables)
 
         return node_initialized

--- a/menuflow/nodes/base.py
+++ b/menuflow/nodes/base.py
@@ -150,14 +150,14 @@ class Base:
                 self.log.exception(e)
                 return
 
-        self.variables.update(self.room._variables)
+        copy_variables = {**self.variables, **self.room._variables}
 
         try:
-            data = loads(data_template.render(**self.variables))
+            data = loads(data_template.render(**copy_variables))
             data = convert_to_bool(data)
             return data
         except JSONDecodeError:
-            data = data_template.render(**self.variables)
+            data = data_template.render(**copy_variables)
             return convert_to_bool(data)
         except KeyError:
             data = loads(data_template.render())


### PR DESCRIPTION
Node variables are not cleanup properly when menu leaves the room, I changed nodes variables mapping in render_data method to prevent process old variables in a new conversation.