### PR TITLE
Transform nats stream parameter to uppercase

### DIFF
--- a/menuflow/example-config.yaml
+++ b/menuflow/example-config.yaml
@@ -69,7 +69,7 @@ nats:
     # Nats password
     password: "nats"
     # Stream name to publish messages
-    stream: "menuflow_company_name"
+    stream: "MENUFLOW_COMPANY_NAME"
     # Subject to publish messages
     subject: "menuflow.company_name"
 


### PR DESCRIPTION
To comply with the agreed standard for names in the nats configuration, the stream value is transformed to uppercase